### PR TITLE
Bump org.apache.kafka:kafka-clients from 3.7.2 to 3.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>3.7.2</version>
+			<version>3.9.0</version>
 		</dependency>
 
 


### PR DESCRIPTION
Bumps org.apache.kafka:kafka-clients from 3.7.2 to 3.9.0.
